### PR TITLE
Remove two pointless lines from queuestream.c

### DIFF
--- a/src/queuestream.c
+++ b/src/queuestream.c
@@ -153,8 +153,6 @@ static ssize_t do_read(queuestream_t *qstr, void *buf, size_t count)
         qstr->pending_errno = 0;
         return -1;
     }
-    if ((ssize_t) count < 0)
-        count = (size_t) -1 >> 1;
     size_t cursor = 0;
     while (cursor < count && !list_empty(qstr->queue)) {
         list_elem_t *head_elem = list_get_first(qstr->queue);


### PR DESCRIPTION
I might have been the author of these strange lines, but whatever the purpose remains a mystery. They have no useful effect (or harmful, either, for that matter).